### PR TITLE
navigation bar issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ class App extends Component {
   render() {
     return (
       <Layout>
-        <h2>Testing fixed navbar, if you can't see me it works!</h2>
+        <p>You can not see this, but if you change this to any h1-h6 tag you would be able to see the text.</p>
       </Layout>
     );
   }


### PR DESCRIPTION
When we replace the p tag by any header tag in the range of 1-6 the text is being shown.
Maybe because of the default margin and the padding added by the browser stylesheet.
We should look into it. 